### PR TITLE
Feat/layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.4.1",
     "@emotion/server": "^11.4.0",
     "@emotion/styled": "^11.3.0",
+    "@mui/icons-material": "^5.0.1",
     "@mui/material": "^5.0.0",
     "@mui/styles": "^5.0.0",
     "axios": "^0.21.2",

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -1,0 +1,31 @@
+import { Avatar, IconButton, Typography } from '@mui/material'
+
+import { Props } from './types'
+
+import * as S from './styles'
+
+function Appbar({ greeting, button }: Props): JSX.Element {
+  const greetingFirstLetter = greeting.substring(0, 1)
+
+  return (
+    <S.AppBar variant="outlined" position="fixed" color="default">
+      <S.Toolbar>
+        {button && (
+          <IconButton size="large" onClick={button.action}>
+            {button.icon}
+          </IconButton>
+        )}
+
+        <S.Profile>
+          <Typography color="textSecondary">{greeting}</Typography>
+
+          <Avatar>
+            <Typography color="inherit">{greetingFirstLetter}</Typography>
+          </Avatar>
+        </S.Profile>
+      </S.Toolbar>
+    </S.AppBar>
+  )
+}
+
+export default Appbar

--- a/src/components/Appbar/Appbar.tsx
+++ b/src/components/Appbar/Appbar.tsx
@@ -8,7 +8,7 @@ function Appbar({ greeting, button }: Props): JSX.Element {
   const greetingFirstLetter = greeting.substring(0, 1)
 
   return (
-    <S.AppBar variant="outlined" position="fixed" color="default">
+    <S.AppBar elevation={0} variant="outlined" position="fixed" color="default">
       <S.Toolbar>
         {button && (
           <IconButton size="large" onClick={button.action}>

--- a/src/components/Appbar/index.ts
+++ b/src/components/Appbar/index.ts
@@ -1,0 +1,3 @@
+export { default } from './Appbar'
+
+export type { AppbarButton } from './types'

--- a/src/components/Appbar/styles.tsx
+++ b/src/components/Appbar/styles.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled'
+
+import { AppBar as MuiAppBar, Toolbar as MuiToolbar } from '@mui/material'
+
+export const AppBar = styled(MuiAppBar)`
+  ${({ theme: { breakpoints, zIndex } }) => `
+    z-index: ${zIndex.drawer + 1};
+
+    ${breakpoints.up('md')} {
+      z-index: ${zIndex.appBar};
+    }
+  `}
+`
+
+export const Toolbar = styled(MuiToolbar)`
+  ${({ theme: { breakpoints } }) => `
+      display: flex;
+      justify-content: space-between;
+
+      ${breakpoints.up('sm')} {
+        flex-direction: row-reverse;
+      }
+  `}
+`
+
+export const Profile = styled.section`
+  ${({ theme: { palette } }) => `
+    display: flex;
+    align-items: center;
+
+    padding: 8px 12px;
+
+    border-radius: 8px;
+
+    &:hover {
+      background-color: ${palette.secondary.main};
+      transition: all .6s;
+      cursor: pointer;
+
+      & > p {
+        color: ${palette.background.default};
+      }
+
+      & .MuiAvatar-root {
+        background-color: ${palette.secondary.dark};
+      }
+    }
+
+    & > .MuiTypography-root {
+      margin-right: 8px;
+    }
+
+    & .MuiAvatar-root {
+      background-color: ${palette.secondary.main};
+
+      width: 32px;
+      height: 32px;
+    }
+  `}
+`

--- a/src/components/Appbar/types.ts
+++ b/src/components/Appbar/types.ts
@@ -1,0 +1,11 @@
+import { ReactElement } from 'react'
+
+export interface AppbarButton {
+  icon: ReactElement
+  action: () => void
+}
+
+export interface Props {
+  greeting: string
+  button?: AppbarButton
+}

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,10 +1,11 @@
 import { FC, useState } from 'react'
 
-import { InboxRounded, MenuOpenRounded, MenuRounded } from '@mui/icons-material'
+import { MenuOpenRounded, MenuRounded } from '@mui/icons-material'
 
-import { List, ListItemIcon, ListItemText, useMediaQuery, useTheme } from '@mui/material'
+import { useMediaQuery, useTheme } from '@mui/material'
 
 import Appbar, { AppbarButton } from '../Appbar'
+import NavigationDrawer from '../NavigationDrawer'
 
 import useAuthenticatedUser from '../../hooks/useAuthenticatedUser'
 
@@ -41,50 +42,7 @@ const Layout: FC = ({ children }) => {
     <S.Wrapper>
       <Appbar greeting={authenticatedUser.name} button={getAppbarButton()} />
 
-      <S.Drawer
-        open={drawerOpen}
-        elevation={0}
-        variant={drawerVariant}
-        onClose={handleCloseDrawer}
-        PaperProps={{ variant: 'outlined' }}
-        anchor="left"
-      >
-        <S.DrawerTitle variant="h6">Teams</S.DrawerTitle>
-
-        <List>
-          <S.ListItem>
-            <ListItemIcon>
-              <InboxRounded />
-            </ListItemIcon>
-
-            <ListItemText>Inicio</ListItemText>
-          </S.ListItem>
-
-          <S.ListItem selected>
-            <ListItemIcon>
-              <InboxRounded />
-            </ListItemIcon>
-
-            <ListItemText>Eventos</ListItemText>
-          </S.ListItem>
-
-          <S.ListItem>
-            <ListItemIcon>
-              <InboxRounded />
-            </ListItemIcon>
-
-            <ListItemText>Times</ListItemText>
-          </S.ListItem>
-
-          <S.ListItem>
-            <ListItemIcon>
-              <InboxRounded />
-            </ListItemIcon>
-
-            <ListItemText>Usuarios</ListItemText>
-          </S.ListItem>
-        </List>
-      </S.Drawer>
+      <NavigationDrawer open={drawerOpen} variant={drawerVariant} onClose={handleCloseDrawer} />
 
       <S.Main>{children}</S.Main>
     </S.Wrapper>

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -2,16 +2,9 @@ import { FC, useState } from 'react'
 
 import { InboxRounded, MenuOpenRounded, MenuRounded } from '@mui/icons-material'
 
-import {
-  Avatar,
-  IconButton,
-  List,
-  ListItemIcon,
-  ListItemText,
-  Typography,
-  useMediaQuery,
-  useTheme,
-} from '@mui/material'
+import { List, ListItemIcon, ListItemText, useMediaQuery, useTheme } from '@mui/material'
+
+import Appbar, { AppbarButton } from '../Appbar'
 
 import useAuthenticatedUser from '../../hooks/useAuthenticatedUser'
 
@@ -19,13 +12,13 @@ import * as S from './styles'
 
 const Layout: FC = ({ children }) => {
   const { breakpoints } = useTheme()
-  const matches = useMediaQuery(breakpoints.up('md'))
+  const isDesktop = useMediaQuery(breakpoints.up('md'))
 
   const [drawerOpen, setDrawerOpen] = useState(false)
 
   const { authenticatedUser } = useAuthenticatedUser()
 
-  const drawerVariant = matches ? 'permanent' : 'temporary'
+  const drawerVariant = isDesktop ? 'permanent' : 'temporary'
 
   function handleToggleDrawer() {
     setDrawerOpen(!drawerOpen)
@@ -35,25 +28,18 @@ const Layout: FC = ({ children }) => {
     setDrawerOpen(false)
   }
 
+  function getAppbarButton() {
+    const buttonOptions: AppbarButton = {
+      icon: drawerOpen ? <MenuOpenRounded /> : <MenuRounded />,
+      action: handleToggleDrawer,
+    }
+
+    return !isDesktop ? buttonOptions : undefined
+  }
+
   return (
     <S.Wrapper>
-      <S.AppBar variant="outlined" position="fixed" color="default">
-        <S.Toolbar>
-          {!matches && (
-            <IconButton size="large" onClick={handleToggleDrawer}>
-              {drawerOpen ? <MenuOpenRounded /> : <MenuRounded />}
-            </IconButton>
-          )}
-
-          <S.Profile>
-            <Typography color="textSecondary">{authenticatedUser.name}</Typography>
-
-            <Avatar>
-              <Typography color="inherit">J</Typography>
-            </Avatar>
-          </S.Profile>
-        </S.Toolbar>
-      </S.AppBar>
+      <Appbar greeting={authenticatedUser.name} button={getAppbarButton()} />
 
       <S.Drawer
         open={drawerOpen}

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,27 +1,29 @@
-import { useState } from 'react'
+import { FC, useState } from 'react'
 
 import { InboxRounded, MenuOpenRounded, MenuRounded } from '@mui/icons-material'
+
 import {
+  Avatar,
   IconButton,
   List,
-  ListItem,
   ListItemIcon,
   ListItemText,
-  Toolbar,
   Typography,
   useMediaQuery,
   useTheme,
 } from '@mui/material'
 
-import { Props } from './types'
+import useAuthenticatedUser from '../../hooks/useAuthenticatedUser'
 
 import * as S from './styles'
 
-function Layout({ children }: Props): JSX.Element {
+const Layout: FC = ({ children }) => {
   const { breakpoints } = useTheme()
   const matches = useMediaQuery(breakpoints.up('md'))
 
   const [drawerOpen, setDrawerOpen] = useState(false)
+
+  const { authenticatedUser } = useAuthenticatedUser()
 
   const drawerVariant = matches ? 'permanent' : 'temporary'
 
@@ -34,16 +36,24 @@ function Layout({ children }: Props): JSX.Element {
   }
 
   return (
-    <>
-      <S.AppBar position="fixed">
-        <Toolbar>
-          <IconButton size="large" color="secondary" onClick={handleToggleDrawer}>
-            {drawerOpen ? <MenuOpenRounded /> : <MenuRounded />}
-          </IconButton>
-        </Toolbar>
-      </S.AppBar>
+    <S.Wrapper>
+      <S.AppBar variant="outlined" position="fixed" color="default">
+        <S.Toolbar>
+          {!matches && (
+            <IconButton size="large" onClick={handleToggleDrawer}>
+              {drawerOpen ? <MenuOpenRounded /> : <MenuRounded />}
+            </IconButton>
+          )}
 
-      <S.Main>{children}</S.Main>
+          <S.Profile>
+            <Typography color="textSecondary">{authenticatedUser.name}</Typography>
+
+            <Avatar>
+              <Typography color="inherit">J</Typography>
+            </Avatar>
+          </S.Profile>
+        </S.Toolbar>
+      </S.AppBar>
 
       <S.Drawer
         open={drawerOpen}
@@ -51,44 +61,47 @@ function Layout({ children }: Props): JSX.Element {
         variant={drawerVariant}
         onClose={handleCloseDrawer}
         PaperProps={{ variant: 'outlined' }}
+        anchor="left"
       >
         <S.DrawerTitle variant="h6">Teams</S.DrawerTitle>
 
         <List>
-          <ListItem button>
+          <S.ListItem>
             <ListItemIcon>
               <InboxRounded />
             </ListItemIcon>
 
-            <ListItemText>Item 1</ListItemText>
-          </ListItem>
+            <ListItemText>Inicio</ListItemText>
+          </S.ListItem>
 
-          <ListItem selected>
+          <S.ListItem selected>
             <ListItemIcon>
               <InboxRounded />
             </ListItemIcon>
 
-            <ListItemText>Item 2</ListItemText>
-          </ListItem>
+            <ListItemText>Eventos</ListItemText>
+          </S.ListItem>
 
-          <ListItem button>
+          <S.ListItem>
             <ListItemIcon>
               <InboxRounded />
             </ListItemIcon>
 
-            <ListItemText>Item 3</ListItemText>
-          </ListItem>
+            <ListItemText>Times</ListItemText>
+          </S.ListItem>
 
-          <ListItem button>
+          <S.ListItem>
             <ListItemIcon>
               <InboxRounded />
             </ListItemIcon>
 
-            <ListItemText>Item 4</ListItemText>
-          </ListItem>
+            <ListItemText>Usuarios</ListItemText>
+          </S.ListItem>
         </List>
       </S.Drawer>
-    </>
+
+      <S.Main>{children}</S.Main>
+    </S.Wrapper>
   )
 }
 

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,7 +1,17 @@
 import { useState } from 'react'
 
-import { MenuOpenRounded, MenuRounded } from '@mui/icons-material'
-import { IconButton, Toolbar, Typography, useMediaQuery, useTheme } from '@mui/material'
+import { InboxRounded, MenuOpenRounded, MenuRounded } from '@mui/icons-material'
+import {
+  IconButton,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Toolbar,
+  Typography,
+  useMediaQuery,
+  useTheme,
+} from '@mui/material'
 
 import { Props } from './types'
 
@@ -35,9 +45,48 @@ function Layout({ children }: Props): JSX.Element {
 
       <S.Main>{children}</S.Main>
 
-      <S.Drawer open={drawerOpen} variant={drawerVariant} onClose={handleCloseDrawer}>
-        <Toolbar />
-        <Typography>Blah</Typography>
+      <S.Drawer
+        open={drawerOpen}
+        elevation={0}
+        variant={drawerVariant}
+        onClose={handleCloseDrawer}
+        PaperProps={{ variant: 'outlined' }}
+      >
+        <S.DrawerTitle variant="h6">Teams</S.DrawerTitle>
+
+        <List>
+          <ListItem button>
+            <ListItemIcon>
+              <InboxRounded />
+            </ListItemIcon>
+
+            <ListItemText>Item 1</ListItemText>
+          </ListItem>
+
+          <ListItem selected>
+            <ListItemIcon>
+              <InboxRounded />
+            </ListItemIcon>
+
+            <ListItemText>Item 2</ListItemText>
+          </ListItem>
+
+          <ListItem button>
+            <ListItemIcon>
+              <InboxRounded />
+            </ListItemIcon>
+
+            <ListItemText>Item 3</ListItemText>
+          </ListItem>
+
+          <ListItem button>
+            <ListItemIcon>
+              <InboxRounded />
+            </ListItemIcon>
+
+            <ListItemText>Item 4</ListItemText>
+          </ListItem>
+        </List>
       </S.Drawer>
     </>
   )

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+
+import { MenuOpenRounded, MenuRounded } from '@mui/icons-material'
+import { IconButton, Toolbar, Typography, useMediaQuery, useTheme } from '@mui/material'
+
+import { Props } from './types'
+
+import * as S from './styles'
+
+function Layout({ children }: Props): JSX.Element {
+  const { breakpoints } = useTheme()
+  const matches = useMediaQuery(breakpoints.up('md'))
+
+  const [drawerOpen, setDrawerOpen] = useState(false)
+
+  const drawerVariant = matches ? 'permanent' : 'temporary'
+
+  function handleToggleDrawer() {
+    setDrawerOpen(!drawerOpen)
+  }
+
+  function handleCloseDrawer() {
+    setDrawerOpen(false)
+  }
+
+  return (
+    <>
+      <S.AppBar position="fixed">
+        <Toolbar>
+          <IconButton size="large" color="secondary" onClick={handleToggleDrawer}>
+            {drawerOpen ? <MenuOpenRounded /> : <MenuRounded />}
+          </IconButton>
+        </Toolbar>
+      </S.AppBar>
+
+      <S.Main>{children}</S.Main>
+
+      <S.Drawer open={drawerOpen} variant={drawerVariant} onClose={handleCloseDrawer}>
+        <Toolbar />
+        <Typography>Blah</Typography>
+      </S.Drawer>
+    </>
+  )
+}
+
+export default Layout

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Layout'

--- a/src/components/Layout/styles.ts
+++ b/src/components/Layout/styles.ts
@@ -1,8 +1,19 @@
 import styled from '@emotion/styled'
-import { AppBar as MuiAppBar, Drawer as MuiDrawer, Typography } from '@mui/material'
+
+import {
+  AppBar as MuiAppBar,
+  Drawer as MuiDrawer,
+  ListItem as MuiListItem,
+  Toolbar as MuiToolbar,
+  Typography,
+} from '@mui/material'
+
+export const Wrapper = styled.section`
+  display: flex;
+`
 
 export const AppBar = styled(MuiAppBar)`
-  ${({ theme: { zIndex, breakpoints } }) => `
+  ${({ theme: { breakpoints, zIndex } }) => `
     z-index: ${zIndex.drawer + 1};
 
     ${breakpoints.up('md')} {
@@ -12,7 +23,7 @@ export const AppBar = styled(MuiAppBar)`
 `
 
 export const Drawer = styled(MuiDrawer)`
-  ${({ theme: { breakpoints } }) => `
+  ${({ theme: { breakpoints, palette } }) => `
     & .MuiPaper-root {
       padding-top: 56px;
       padding-left: 16px;
@@ -20,9 +31,17 @@ export const Drawer = styled(MuiDrawer)`
 
       width: 70%;
 
+      background-color: ${palette.background.default};
+
       ${breakpoints.up('md')} {
-        width: 300px;
+        flex-shrink: 0;
+        padding-top: 0px;
+        max-width: 300px;
       }
+    }
+
+    ${breakpoints.up('md')} {
+      width: 300px;
     }
   `}
 `
@@ -31,12 +50,87 @@ export const DrawerTitle = styled(Typography)`
   margin-top: 24px;
 `
 
-export const Main = styled.main`
+export const ListItem = styled(MuiListItem)`
   ${({ theme: { palette } }) => `
+    &.Mui-selected {
+      background-color: ${palette.secondary.main};
+      color: ${palette.common.white};
+
+      &:hover {
+        background-color: ${palette.secondary.light};
+      }
+
+      & .MuiSvgIcon-root {
+        fill: ${palette.common.white};
+      }
+    }
+
+    &:hover {
+      background-color: ${palette.action.hover};
+      cursor: pointer;
+    }
+  `}
+`
+
+export const Toolbar = styled(MuiToolbar)`
+  ${({ theme: { breakpoints } }) => `
+      display: flex;
+      justify-content: space-between;
+
+      ${breakpoints.up('sm')} {
+        flex-direction: row-reverse;
+      }
+  `}
+`
+
+export const Profile = styled.section`
+  ${({ theme: { palette } }) => `
+    display: flex;
+    align-items: center;
+
+    padding: 8px 12px;
+
+    border-radius: 8px;
+
+    &:hover {
+      background-color: ${palette.secondary.main};
+      transition: all .6s;
+      cursor: pointer;
+
+      & > p {
+        color: ${palette.background.default};
+      }
+
+      & .MuiAvatar-root {
+        background-color: ${palette.secondary.dark};
+      }
+    }
+
+    & > .MuiTypography-root {
+      margin-right: 8px;
+    }
+
+    & .MuiAvatar-root {
+      background-color: ${palette.secondary.main};
+
+      width: 32px;
+      height: 32px;
+    }
+  `}
+`
+
+export const Main = styled.main`
+  ${({ theme: { breakpoints, palette } }) => `
+    flex-grow: 1;
+
     padding-top: 56px;
 
-    height: 100vh;
+    min-height: 100vh;
 
-    background-color: ${palette.background.default}
+    background-color: ${palette.background.default};
+
+    ${breakpoints.up('sm')} {
+      padding-top: 64px;
+    }
   `}
 `

--- a/src/components/Layout/styles.ts
+++ b/src/components/Layout/styles.ts
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled'
+import { AppBar as MuiAppBar, Drawer as MuiDrawer } from '@mui/material'
+
+export const AppBar = styled(MuiAppBar)`
+  ${({ theme: { zIndex, breakpoints } }) => `
+    z-index: ${zIndex.drawer + 1}
+  `}
+`
+
+export const Drawer = styled(MuiDrawer)`
+  ${({ theme: { breakpoints } }) => `
+    & .MuiPaper-root {
+      width: 70%;
+    }
+  `}
+`
+
+export const Main = styled.main`
+  ${({ theme: { palette } }) => `
+    padding-top: 56px;
+
+    height: 100vh;
+
+    background-color: ${palette.background.default}
+  `}
+`

--- a/src/components/Layout/styles.ts
+++ b/src/components/Layout/styles.ts
@@ -1,18 +1,34 @@
 import styled from '@emotion/styled'
-import { AppBar as MuiAppBar, Drawer as MuiDrawer } from '@mui/material'
+import { AppBar as MuiAppBar, Drawer as MuiDrawer, Typography } from '@mui/material'
 
 export const AppBar = styled(MuiAppBar)`
   ${({ theme: { zIndex, breakpoints } }) => `
-    z-index: ${zIndex.drawer + 1}
+    z-index: ${zIndex.drawer + 1};
+
+    ${breakpoints.up('md')} {
+      z-index: ${zIndex.appBar};
+    }
   `}
 `
 
 export const Drawer = styled(MuiDrawer)`
   ${({ theme: { breakpoints } }) => `
     & .MuiPaper-root {
+      padding-top: 56px;
+      padding-left: 16px;
+      padding-right: 16px;
+
       width: 70%;
+
+      ${breakpoints.up('md')} {
+        width: 300px;
+      }
     }
   `}
+`
+
+export const DrawerTitle = styled(Typography)`
+  margin-top: 24px;
 `
 
 export const Main = styled.main`

--- a/src/components/Layout/styles.ts
+++ b/src/components/Layout/styles.ts
@@ -1,59 +1,7 @@
 import styled from '@emotion/styled'
 
-import { Drawer as MuiDrawer, ListItem as MuiListItem, Typography } from '@mui/material'
-
 export const Wrapper = styled.section`
   display: flex;
-`
-
-export const Drawer = styled(MuiDrawer)`
-  ${({ theme: { breakpoints, palette } }) => `
-    & .MuiPaper-root {
-      padding-top: 56px;
-      padding-left: 16px;
-      padding-right: 16px;
-
-      width: 70%;
-
-      background-color: ${palette.background.default};
-
-      ${breakpoints.up('md')} {
-        flex-shrink: 0;
-        padding-top: 0px;
-        max-width: 300px;
-      }
-    }
-
-    ${breakpoints.up('md')} {
-      width: 300px;
-    }
-  `}
-`
-
-export const DrawerTitle = styled(Typography)`
-  margin-top: 24px;
-`
-
-export const ListItem = styled(MuiListItem)`
-  ${({ theme: { palette } }) => `
-    &.Mui-selected {
-      background-color: ${palette.secondary.main};
-      color: ${palette.common.white};
-
-      &:hover {
-        background-color: ${palette.secondary.light};
-      }
-
-      & .MuiSvgIcon-root {
-        fill: ${palette.common.white};
-      }
-    }
-
-    &:hover {
-      background-color: ${palette.action.hover};
-      cursor: pointer;
-    }
-  `}
 `
 
 export const Main = styled.main`

--- a/src/components/Layout/styles.ts
+++ b/src/components/Layout/styles.ts
@@ -1,25 +1,9 @@
 import styled from '@emotion/styled'
 
-import {
-  AppBar as MuiAppBar,
-  Drawer as MuiDrawer,
-  ListItem as MuiListItem,
-  Toolbar as MuiToolbar,
-  Typography,
-} from '@mui/material'
+import { Drawer as MuiDrawer, ListItem as MuiListItem, Typography } from '@mui/material'
 
 export const Wrapper = styled.section`
   display: flex;
-`
-
-export const AppBar = styled(MuiAppBar)`
-  ${({ theme: { breakpoints, zIndex } }) => `
-    z-index: ${zIndex.drawer + 1};
-
-    ${breakpoints.up('md')} {
-      z-index: ${zIndex.appBar};
-    }
-  `}
 `
 
 export const Drawer = styled(MuiDrawer)`
@@ -68,53 +52,6 @@ export const ListItem = styled(MuiListItem)`
     &:hover {
       background-color: ${palette.action.hover};
       cursor: pointer;
-    }
-  `}
-`
-
-export const Toolbar = styled(MuiToolbar)`
-  ${({ theme: { breakpoints } }) => `
-      display: flex;
-      justify-content: space-between;
-
-      ${breakpoints.up('sm')} {
-        flex-direction: row-reverse;
-      }
-  `}
-`
-
-export const Profile = styled.section`
-  ${({ theme: { palette } }) => `
-    display: flex;
-    align-items: center;
-
-    padding: 8px 12px;
-
-    border-radius: 8px;
-
-    &:hover {
-      background-color: ${palette.secondary.main};
-      transition: all .6s;
-      cursor: pointer;
-
-      & > p {
-        color: ${palette.background.default};
-      }
-
-      & .MuiAvatar-root {
-        background-color: ${palette.secondary.dark};
-      }
-    }
-
-    & > .MuiTypography-root {
-      margin-right: 8px;
-    }
-
-    & .MuiAvatar-root {
-      background-color: ${palette.secondary.main};
-
-      width: 32px;
-      height: 32px;
     }
   `}
 `

--- a/src/components/Layout/types.ts
+++ b/src/components/Layout/types.ts
@@ -1,0 +1,3 @@
+export interface Props {
+  children: React.ReactElement
+}

--- a/src/components/Layout/types.ts
+++ b/src/components/Layout/types.ts
@@ -1,3 +1,0 @@
-export interface Props {
-  children: React.ReactElement
-}

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -1,0 +1,20 @@
+import { ListItemIcon, ListItemText } from '@mui/material'
+
+import { Props } from './types'
+
+import * as S from './styles'
+
+function List({ items }: Props): JSX.Element {
+  return (
+    <S.List>
+      {items.map(({ icon, text, selected }) => (
+        <S.ListItem key={text} selected={selected}>
+          <ListItemIcon>{icon}</ListItemIcon>
+          <ListItemText>{text}</ListItemText>
+        </S.ListItem>
+      ))}
+    </S.List>
+  )
+}
+
+export default List

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -1,4 +1,4 @@
-import { ListItemIcon, ListItemText } from '@mui/material'
+import { List as MuiList, ListItemIcon, ListItemText } from '@mui/material'
 
 import { Props } from './types'
 
@@ -6,14 +6,14 @@ import * as S from './styles'
 
 function List({ items }: Props): JSX.Element {
   return (
-    <S.List>
+    <MuiList>
       {items.map(({ icon, text, selected }) => (
         <S.ListItem key={text} selected={selected}>
           <ListItemIcon>{icon}</ListItemIcon>
           <ListItemText>{text}</ListItemText>
         </S.ListItem>
       ))}
-    </S.List>
+    </MuiList>
   )
 }
 

--- a/src/components/List/index.ts
+++ b/src/components/List/index.ts
@@ -1,0 +1,3 @@
+export { default } from './List'
+
+export type { ListItem } from './types'

--- a/src/components/List/styles.ts
+++ b/src/components/List/styles.ts
@@ -1,10 +1,6 @@
 import styled from '@emotion/styled'
 
-import { List as MuiList, ListItem as MuiListItem } from '@mui/material'
-
-export const List = styled(MuiList)`
-  margin-top: 16px;
-`
+import { ListItem as MuiListItem } from '@mui/material'
 
 export const ListItem = styled(MuiListItem)`
   ${({ theme: { palette } }) => `

--- a/src/components/List/styles.ts
+++ b/src/components/List/styles.ts
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled'
+
+import { List as MuiList, ListItem as MuiListItem } from '@mui/material'
+
+export const List = styled(MuiList)`
+  margin-top: 16px;
+`
+
+export const ListItem = styled(MuiListItem)`
+  ${({ theme: { palette } }) => `
+    &.Mui-selected {
+      background-color: ${palette.secondary.main};
+      color: ${palette.common.white};
+
+      &:hover {
+        background-color: ${palette.secondary.light};
+      }
+
+      & .MuiSvgIcon-root {
+        fill: ${palette.common.white};
+      }
+    }
+
+    &:hover {
+      background-color: ${palette.action.hover};
+      cursor: pointer;
+    }
+  `}
+`

--- a/src/components/List/types.ts
+++ b/src/components/List/types.ts
@@ -1,0 +1,11 @@
+import { ReactElement } from 'react'
+
+export interface ListItem {
+  icon: ReactElement
+  text: string
+  selected?: boolean
+}
+
+export interface Props {
+  items: ListItem[]
+}

--- a/src/components/NavigationDrawer/NavigationDrawer.tsx
+++ b/src/components/NavigationDrawer/NavigationDrawer.tsx
@@ -1,10 +1,30 @@
-import { InboxRounded } from '@mui/icons-material'
+import { DashboardRounded, EventRounded, GroupRounded, WorkspacesRounded } from '@mui/icons-material'
 
-import { List, ListItemIcon, ListItemText } from '@mui/material'
+import List, { ListItem } from '../List'
 
 import { Props } from './types'
 
 import * as S from './styles'
+
+const navigationItems: ListItem[] = [
+  {
+    icon: <DashboardRounded />,
+    text: 'Início',
+    selected: true,
+  },
+  {
+    icon: <EventRounded />,
+    text: 'Eventos',
+  },
+  {
+    icon: <WorkspacesRounded />,
+    text: 'Times',
+  },
+  {
+    icon: <GroupRounded />,
+    text: 'Usuarios',
+  },
+]
 
 function NavigationDrawer({ open, variant, onClose }: Props): JSX.Element {
   return (
@@ -18,39 +38,7 @@ function NavigationDrawer({ open, variant, onClose }: Props): JSX.Element {
     >
       <S.DrawerTitle variant="h6">Teams</S.DrawerTitle>
 
-      <List>
-        <S.ListItem>
-          <ListItemIcon>
-            <InboxRounded />
-          </ListItemIcon>
-
-          <ListItemText>Inicio</ListItemText>
-        </S.ListItem>
-
-        <S.ListItem selected>
-          <ListItemIcon>
-            <InboxRounded />
-          </ListItemIcon>
-
-          <ListItemText>Eventos</ListItemText>
-        </S.ListItem>
-
-        <S.ListItem>
-          <ListItemIcon>
-            <InboxRounded />
-          </ListItemIcon>
-
-          <ListItemText>Times</ListItemText>
-        </S.ListItem>
-
-        <S.ListItem>
-          <ListItemIcon>
-            <InboxRounded />
-          </ListItemIcon>
-
-          <ListItemText>Usuarios</ListItemText>
-        </S.ListItem>
-      </List>
+      <List items={navigationItems} />
     </S.Drawer>
   )
 }

--- a/src/components/NavigationDrawer/NavigationDrawer.tsx
+++ b/src/components/NavigationDrawer/NavigationDrawer.tsx
@@ -1,0 +1,58 @@
+import { InboxRounded } from '@mui/icons-material'
+
+import { List, ListItemIcon, ListItemText } from '@mui/material'
+
+import { Props } from './types'
+
+import * as S from './styles'
+
+function NavigationDrawer({ open, variant, onClose }: Props): JSX.Element {
+  return (
+    <S.Drawer
+      open={open}
+      elevation={0}
+      variant={variant}
+      onClose={onClose}
+      PaperProps={{ variant: 'outlined' }}
+      anchor="left"
+    >
+      <S.DrawerTitle variant="h6">Teams</S.DrawerTitle>
+
+      <List>
+        <S.ListItem>
+          <ListItemIcon>
+            <InboxRounded />
+          </ListItemIcon>
+
+          <ListItemText>Inicio</ListItemText>
+        </S.ListItem>
+
+        <S.ListItem selected>
+          <ListItemIcon>
+            <InboxRounded />
+          </ListItemIcon>
+
+          <ListItemText>Eventos</ListItemText>
+        </S.ListItem>
+
+        <S.ListItem>
+          <ListItemIcon>
+            <InboxRounded />
+          </ListItemIcon>
+
+          <ListItemText>Times</ListItemText>
+        </S.ListItem>
+
+        <S.ListItem>
+          <ListItemIcon>
+            <InboxRounded />
+          </ListItemIcon>
+
+          <ListItemText>Usuarios</ListItemText>
+        </S.ListItem>
+      </List>
+    </S.Drawer>
+  )
+}
+
+export default NavigationDrawer

--- a/src/components/NavigationDrawer/NavigationDrawer.tsx
+++ b/src/components/NavigationDrawer/NavigationDrawer.tsx
@@ -38,7 +38,9 @@ function NavigationDrawer({ open, variant, onClose }: Props): JSX.Element {
     >
       <S.DrawerTitle variant="h6">Teams</S.DrawerTitle>
 
-      <List items={navigationItems} />
+      <S.Content>
+        <List items={navigationItems} />
+      </S.Content>
     </S.Drawer>
   )
 }

--- a/src/components/NavigationDrawer/index.ts
+++ b/src/components/NavigationDrawer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NavigationDrawer'

--- a/src/components/NavigationDrawer/styles.ts
+++ b/src/components/NavigationDrawer/styles.ts
@@ -51,3 +51,7 @@ export const ListItem = styled(MuiListItem)`
     }
   `}
 `
+
+export const Content = styled.main`
+  margin-top: 16px;
+`

--- a/src/components/NavigationDrawer/styles.ts
+++ b/src/components/NavigationDrawer/styles.ts
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled'
+
+import { Drawer as MuiDrawer, ListItem as MuiListItem, Typography } from '@mui/material'
+
+export const Drawer = styled(MuiDrawer)`
+  ${({ theme: { breakpoints, palette } }) => `
+    & .MuiPaper-root {
+      padding-top: 56px;
+      padding-left: 16px;
+      padding-right: 16px;
+
+      width: 70%;
+
+      background-color: ${palette.background.default};
+
+      ${breakpoints.up('md')} {
+        flex-shrink: 0;
+        padding-top: 0px;
+        max-width: 300px;
+      }
+    }
+
+    ${breakpoints.up('md')} {
+      width: 300px;
+    }
+  `}
+`
+
+export const DrawerTitle = styled(Typography)`
+  margin-top: 24px;
+`
+
+export const ListItem = styled(MuiListItem)`
+  ${({ theme: { palette } }) => `
+    &.Mui-selected {
+      background-color: ${palette.secondary.main};
+      color: ${palette.common.white};
+
+      &:hover {
+        background-color: ${palette.secondary.light};
+      }
+
+      & .MuiSvgIcon-root {
+        fill: ${palette.common.white};
+      }
+    }
+
+    &:hover {
+      background-color: ${palette.action.hover};
+      cursor: pointer;
+    }
+  `}
+`

--- a/src/components/NavigationDrawer/types.ts
+++ b/src/components/NavigationDrawer/types.ts
@@ -1,0 +1,7 @@
+import { DrawerProps } from '@mui/material'
+
+export interface Props {
+  open: boolean
+  variant: DrawerProps['variant']
+  onClose: () => void
+}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,4 +1,6 @@
 import Link from 'next/link'
+import { Container, Typography } from '@mui/material'
+
 import Layout from '../../components/Layout'
 import useAuthenticatedUser from '../../hooks/useAuthenticatedUser'
 
@@ -7,8 +9,10 @@ const Home: React.FC = () => {
 
   return (
     <Layout>
-      <h1>Olá, {authenticatedUser.name}</h1>
-      <Link href="/profile">profile</Link>
+      <Container maxWidth="md">
+        <Typography>Olá, {authenticatedUser.name}</Typography>
+        <Link href="/profile">profile</Link>
+      </Container>
     </Layout>
   )
 }

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,14 +1,15 @@
 import Link from 'next/link'
+import Layout from '../../components/Layout'
 import useAuthenticatedUser from '../../hooks/useAuthenticatedUser'
 
 const Home: React.FC = () => {
   const { authenticatedUser } = useAuthenticatedUser()
 
   return (
-    <>
+    <Layout>
       <h1>Olá, {authenticatedUser.name}</h1>
       <Link href="/profile">profile</Link>
-    </>
+    </Layout>
   )
 }
 

--- a/src/styles/Theme.tsx
+++ b/src/styles/Theme.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 
 import { ThemeProvider as EmotionProvider } from '@emotion/react'
 
-import { ThemeProvider as MuiTheme, createTheme, adaptV4Theme } from '@mui/material'
+import { ThemeProvider as MuiTheme, createTheme } from '@mui/material'
 
 export const ThemeProvider: FC = ({ children }) => {
   const theme = createTheme({
@@ -50,7 +50,7 @@ export const ThemeProvider: FC = ({ children }) => {
         main: '#5fa8d3',
       },
       background: {
-        default: '#f2f2f2',
+        default: '#f7f7f7',
         paper: '#ffffff',
       },
       text: {
@@ -59,6 +59,13 @@ export const ThemeProvider: FC = ({ children }) => {
       },
     },
     components: {
+      MuiAppBar: {
+        styleOverrides: {
+          colorDefault: {
+            backgroundColor: '#f7f7f7',
+          },
+        },
+      },
       MuiButton: {
         styleOverrides: {
           root: {
@@ -83,7 +90,6 @@ export const ThemeProvider: FC = ({ children }) => {
       MuiListItem: {
         styleOverrides: {
           root: {
-            padding: '16px',
             borderRadius: '8px',
             marginBottom: '8px',
           },

--- a/src/styles/Theme.tsx
+++ b/src/styles/Theme.tsx
@@ -80,6 +80,23 @@ export const ThemeProvider: FC = ({ children }) => {
           },
         },
       },
+      MuiListItem: {
+        styleOverrides: {
+          root: {
+            padding: '16px',
+            borderRadius: '8px',
+            marginBottom: '8px',
+          },
+        },
+      },
+      MuiListItemIcon: {
+        styleOverrides: {
+          root: {
+            minWidth: '0px',
+            marginRight: '16px',
+          },
+        },
+      },
     },
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -299,7 +299,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.13.10", "@babel/runtime@^7.14.8", "@babel/runtime@^7.7.2":
+"@babel/runtime@^7.13.10", "@babel/runtime@^7.14.8", "@babel/runtime@^7.15.4", "@babel/runtime@^7.7.2":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
   integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
@@ -704,6 +704,13 @@
     clsx "^1.1.1"
     prop-types "^15.7.2"
     react-is "^17.0.2"
+
+"@mui/icons-material@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.0.1.tgz#fb7ffeba0b3604aab4a9b91644d2fc1aabb3b4f1"
+  integrity sha512-AZehR/Uvi9VodsNPk9ae1lENKrf1evqx9suiP6VIqu7NxjZOlw/m/yA2gRAMmLEmIGr7EChfi/wcXuq6BpM9vw==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
 
 "@mui/material@^5.0.0":
   version "5.0.0"


### PR DESCRIPTION
# ✨ Add layout component

## Motivation
In order to give a default navigation for all pages, lets create a `Layout` component to handle the navigation.

## Changes
- install `@mui/material-icons`
- add `Appbar` component
- add `Layout` component
- apply `Layout` on `Home` page
- add `List` component
- add `Drawer` component